### PR TITLE
- Replace deprecated async_forward_entry_setup

### DIFF
--- a/custom_components/recycle_app/__init__.py
+++ b/custom_components/recycle_app/__init__.py
@@ -133,12 +133,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         recycling_park_coordinator=parks_coordinator,
     )
 
-    for platform in PLATFORMS:
-        # Forward the setup to the target platform.
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
-
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
 


### PR DESCRIPTION
- await the call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of platform entry setups to enhance performance and reliability of the recycling app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->