### PR TITLE
fix: configFlow 'list' object has no attribute 'split'

### DIFF
--- a/custom_components/recycle_app/config_flow.py
+++ b/custom_components/recycle_app/config_flow.py
@@ -309,8 +309,8 @@ class RecycleAppOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         "recyclingParkZipCode",
                         default=str(
-                            self.config_entry.options.get("recyclingParkZipCode", [""])[0]
-                        ).split("-")[0],
+                            next(iter(self.config_entry.options.get("recyclingParkZipCode", [])), "")
+                        ).partition("-")[0],
                     ): OptionalInt(),
                 }
             ),

--- a/custom_components/recycle_app/config_flow.py
+++ b/custom_components/recycle_app/config_flow.py
@@ -309,8 +309,8 @@ class RecycleAppOptionsFlowHandler(config_entries.OptionsFlow):
                     ): str,
                     vol.Optional(
                         "recyclingParkZipCode",
-                        default=self.config_entry.options.get(
-                            "recyclingParkZipCode", ""
+                        default=str(
+                            self.config_entry.options.get("recyclingParkZipCode", [""])[0]
                         ).split("-")[0],
                     ): OptionalInt(),
                 }

--- a/custom_components/recycle_app/config_flow.py
+++ b/custom_components/recycle_app/config_flow.py
@@ -242,7 +242,6 @@ class RecycleAppOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
         self._parks = None
         self._data = None
 


### PR DESCRIPTION
Fixes #96 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of recycling park zip code selection in configuration flow.
	- Enhanced default value retrieval for park options.
	- Refined park selection logic to ensure accurate user input processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->