### PR TITLE
Pass config_entry to DataUpdateCoordinator to remove ContextVar warning.

### DIFF
--- a/custom_components/recycle_app/__init__.py
+++ b/custom_components/recycle_app/__init__.py
@@ -123,6 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
+        config_entry=entry,
         name="RecycleAppGetCollections",
         update_method=async_update_collections,
     )
@@ -130,6 +131,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     parks_coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
+        config_entry=entry,
         name="RecycleAppGetRecyclingParks",
         update_method=async_update_parks,
     )

--- a/custom_components/recycle_app/manifest.json
+++ b/custom_components/recycle_app/manifest.json
@@ -10,5 +10,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/olibos/HomeAssistant-RecycleApp/issues",
   "requirements": [],
-  "version": "2.5.1"
+  "version": "3.0.0",
+  "homeassistant": "2024.12.0"
 }


### PR DESCRIPTION
Closes #114

Set the new minimum Home Assistant version to 2025.12.0 to ensure compatibility with DataUpdateCoordinator's config_entry argument and prevent ContextVar deprecation warnings.
